### PR TITLE
Resolve duplicate class errors in release build

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -83,6 +83,16 @@ dependencies {
     implementation("androidx.biometric:biometric:1.1.0")
     implementation("androidx.security:security-crypto:1.1.0-alpha06")
     
-    // Google Play Core for deferred components support
-    implementation("com.google.android.play:core:1.10.3")
+    // Ensure we use the latest Play Core Common
+    implementation("com.google.android.play:core-common:2.0.3")
+}
+
+// Force resolution of Play Core dependencies to avoid conflicts
+configurations.all {
+    resolutionStrategy {
+        force("com.google.android.play:core-common:2.0.3")
+        // Prefer newer versions of conflicting dependencies
+        preferProjectModules()
+    }
+    exclude(group = "com.google.android.play", module = "core")
 }


### PR DESCRIPTION
Resolve Android build `Duplicate class` error by updating Google Play Core dependencies and configuring resolution strategy.

The Android build was failing with `Duplicate class` errors because the project explicitly depended on the deprecated `com.google.android.play:core:1.10.3`, which conflicted with `com.google.android.play:core-common:2.0.3` pulled in by other dependencies. This change removes the old dependency and configures Gradle to resolve the conflict by forcing the newer `core-common` and excluding the problematic `core` module.

---
<a href="https://cursor.com/background-agent?bcId=bc-043f782f-1c29-4500-b2c3-895f160a4a26">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-043f782f-1c29-4500-b2c3-895f160a4a26">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

